### PR TITLE
Fix shouldComponentUpdate check

### DIFF
--- a/cmd/reactGen/gen.go
+++ b/cmd/reactGen/gen.go
@@ -356,19 +356,24 @@ func (g *gen) genComp(defName string) {
 	cg.pln()
 
 	cg.pt(`
-func ({{.Recv}} *{{.Name}}Def) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	{{if and .HasProps -}}
+func ({{.Recv}} *{{.Name}}Def) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	{{if .HasProps -}}
+	{
 	{{if .PropsHasEquals -}}
-	return {{.Recv}}.Props().Equals(nextProps.({{.Name}}Props))
+	res = !{{.Recv}}.Props().Equals(nextProps.({{.Name}}Props)) || res
 	{{else -}}
-	return {{.Recv}}.Props() == nextProps.({{.Name}}Props)
+	res = {{.Recv}}.Props() != nextProps.({{.Name}}Props) || res
 	{{end -}}
-	{{else if .HasState -}}
-	return true
-	{{else -}}
-	// no props or state... so nothing would cause this to require re-rendering
-	return false
+	}
 	{{end -}}
+	{{if .HasState -}}
+	v := prevState.({{.Name}}State)
+	res = !v.EqualsIntf(nextState) || res
+	{{end -}}
+
+	return res
 }
 
 {{if .HasState}}

--- a/react/examples/gen_Examples_reactGen.go
+++ b/react/examples/gen_Examples_reactGen.go
@@ -4,8 +4,12 @@ package examples
 
 import "github.com/myitcv/gopherjs/react"
 
-func (e *ExamplesDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (e *ExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(ExamplesState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/react/examples/gen_ImmExamples_reactGen.go
+++ b/react/examples/gen_ImmExamples_reactGen.go
@@ -4,8 +4,12 @@ package examples
 
 import "github.com/myitcv/gopherjs/react"
 
-func (i *ImmExamplesDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (i *ImmExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(ImmExamplesState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/react/examples/hellomessage/gen_HelloMessage_reactGen.go
+++ b/react/examples/hellomessage/gen_HelloMessage_reactGen.go
@@ -4,8 +4,13 @@ package hellomessage
 
 import "github.com/myitcv/gopherjs/react"
 
-func (h *HelloMessageDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return h.Props() == nextProps.(HelloMessageProps)
+func (h *HelloMessageDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	{
+		res = h.Props() != nextProps.(HelloMessageProps) || res
+	}
+	return res
 }
 
 // Props is an auto-generated proxy to the current props of HelloMessage

--- a/react/examples/hellomessage/hello_message.go
+++ b/react/examples/hellomessage/hello_message.go
@@ -22,9 +22,7 @@ type HelloMessageProps struct {
 // HelloMessage creates instances of the HelloMessage component
 func HelloMessage(p HelloMessageProps) *HelloMessageDef {
 	res := &HelloMessageDef{}
-
 	r.BlessElement(res, p)
-
 	return res
 }
 

--- a/react/examples/immtodoapp/gen_TodoApp_reactGen.go
+++ b/react/examples/immtodoapp/gen_TodoApp_reactGen.go
@@ -4,8 +4,12 @@ package immtodoapp
 
 import "github.com/myitcv/gopherjs/react"
 
-func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(TodoAppState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/react/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
+++ b/react/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
@@ -4,8 +4,12 @@ package markdowneditor
 
 import "github.com/myitcv/gopherjs/react"
 
-func (m *MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (m *MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(MarkdownEditorState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/react/examples/timer/gen_Timer_reactGen.go
+++ b/react/examples/timer/gen_Timer_reactGen.go
@@ -4,8 +4,12 @@ package timer
 
 import "github.com/myitcv/gopherjs/react"
 
-func (t *TimerDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (t *TimerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(TimerState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/react/examples/todoapp/gen_TodoApp_reactGen.go
+++ b/react/examples/todoapp/gen_TodoApp_reactGen.go
@@ -4,8 +4,12 @@ package todoapp
 
 import "github.com/myitcv/gopherjs/react"
 
-func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(TodoAppState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the

--- a/sites/examplesshowcase/gen_App_reactGen.go
+++ b/sites/examplesshowcase/gen_App_reactGen.go
@@ -4,8 +4,12 @@ package main
 
 import "github.com/myitcv/gopherjs/react"
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps interface{}) bool {
-	return true
+func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+	res := false
+
+	v := prevState.(AppState)
+	res = !v.EqualsIntf(nextState) || res
+	return res
 }
 
 // SetState is an auto-generated proxy proxy to update the state for the


### PR DESCRIPTION
There was a bug whereby a component where the props haven't changed would always re-render regardless of the state having changed or not.

There already exists a check that only calls the underlying `setState` if the state has genuinely changed, but this failed to cover the situation where the component itself is re-rendered by its parent component and its props have not changed). In this case, `shouldComponentUpdate` is still called. Where a component had only state and no props, we were unconditionally returning `true`. So we need in effect a double safety net to check the state again (no real cost here)