### PR TITLE
Fix root .gitignore to specifically include certain files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.js
 *.js.map
+!react/internal/dev/dev.inc.js
+!react/internal/prod/prod.inc.js
+!remarkable/remarkable.inc.js
+!sites/common/bootstrap/bootstrap.min.js
+!sites/common/jquery/jquery.min.js


### PR DESCRIPTION
We want to exclude `.js` files by default... so we should specifically list the files we're interested in (we previously force included those files but that doesn't work well when this repo is vendored elsewhere)