### PR TITLE
[WIP] build: initial vgo support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,15 @@ jobs:
           go env
 
       - run: |
+          # Install vgo
+          go get -u golang.org/x/vgo
+          pushd $(go list -f "{{.Dir}}" golang.org/x/vgo) > /dev/null
+          git checkout -qf $VGO_COMMIT
+          go install
+          popd > /dev/null
+          vgo version
+
+      - run: |
           # Per https://github.com/gopherjs/gopherjs/blob/master/doc/syscalls.md.
           npm install --global node-gyp
           cd node-syscall && node-gyp rebuild && mkdir -p $HOME/.node_libraries/ && cp build/Release/syscall.node $HOME/.node_libraries/syscall.node

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -2,11 +2,12 @@ package build
 
 import (
 	"fmt"
-	gobuild "go/build"
 	"go/token"
 	"strconv"
 	"strings"
 	"testing"
+
+	gobuild "github.com/gopherjs/gopherjs/vgobuild"
 
 	"github.com/kisielk/gotool"
 	"github.com/shurcooL/go/importgraphutil"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/myitcv/gopherjs
+
+require (
+	github.com/fsnotify/fsnotify v1.4.7
+	github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f
+	github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86
+	github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab
+	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371
+	golang.org/x/sys v0.0.0-20180704094941-151529c776cd
+	golang.org/x/tools v0.0.0-20180501011915-836e0f611e69
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
+github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f h1:FDM3EtwZLyhW48YRiyqjivNlNZjAObv4xt4NnJaU+NQ=
+github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs/compiler v0.0.0-20180628210949-0892b62f0d9f/go.mod h1:G7mAYYxgmS0lVkHyy2hEOLQCFB0DlQFTMLWggykrydY=
+github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86 h1:D6paGObi5Wud7xg83MaEFyjxQB1W5bz5d0IFppr+ymk=
+github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
+github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab h1:eFXv9Nu1lGbrNbj619aWwZfVF5HBrm9Plte8aNptuTI=
+github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 h1:SWV2fHctRpRrp49VXJ6UZja7gU9QLHwRpIPBN89SKEo=
+github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/httpfs/vfsutil v0.0.0-20171119174359-809beceb2371/go.mod h1:G7mAYYxgmS0lVkHyy2hEOLQCFB0DlQFTMLWggykrydY=
+golang.org/x/sys v0.0.0-20180704094941-151529c776cd h1:KJQ1+cZBZLUUFD04lHVLuma4B5xAJP3LRGuqw08fV2E=
+golang.org/x/sys v0.0.0-20180704094941-151529c776cd/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys/unix v0.0.0-20180704094941-151529c776cd/go.mod h1:G7mAYYxgmS0lVkHyy2hEOLQCFB0DlQFTMLWggykrydY=
+golang.org/x/tools v0.0.0-20180501011915-836e0f611e69 h1:TKIUXzH8tyJweaXIx97Onv5qt4/s/uALQuB938KIXnw=
+golang.org/x/tools v0.0.0-20180501011915-836e0f611e69/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/vgobuild/vgobuild.go
+++ b/vgobuild/vgobuild.go
@@ -1,0 +1,127 @@
+package vgobuild
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"go/build"
+)
+
+var (
+	goCmdName = "go"
+	wd        string
+	pkgMap    map[string]*build.Package
+	useVgo    bool
+)
+
+func init() {
+	var err error
+
+	wd, err = os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	// Per https://go-review.googlesource.com/c/vgo/+/122260 we use the value of
+	// env var GO111MODULE to determine what mode we are in.
+	switch os.Getenv("GO111MODULE") {
+	case "no":
+	case "yes":
+		useVgo = true
+	default:
+		// "auto" or unknown value
+		// for now we simple walk from the current directory up to root
+
+		cd := wd
+
+		for {
+			fn := filepath.Join(cd, "go.mod")
+			fi, err := os.Stat(fn)
+			if err == nil && !fi.IsDir() {
+				useVgo = true
+				break
+			}
+
+			d := filepath.Dir(cd)
+			if d == cd {
+				break
+			}
+			cd = d
+		}
+	}
+
+	if useVgo {
+		goCmdName = "vgo"
+	}
+}
+
+func Import(c *build.Context, path, srcDir string, mode build.ImportMode) (*build.Package, error) {
+	bp, err := c.Import(path, srcDir, mode)
+	if err == nil && bp.Goroot {
+		return bp, nil
+	}
+
+	pkg, ok := pkgMap[path]
+	if !ok {
+		return nil, fmt.Errorf("failed to resolve %v; not in pkgMap", path)
+	}
+	return pkg, nil
+}
+
+func ImportDir(c *build.Context, dir string, mode build.ImportMode) (*build.Package, error) {
+	panic("ImportDir not implemented yet")
+}
+
+// Every GopherJS command resolves import path patterns via this method
+// which means we can use it as a hook for pre-fetching all the vgo deps
+// if we are in vgo mode
+func ImportPaths(c *build.Context, patterns []string) ([]string, error) {
+	if len(patterns) == 0 {
+		patterns = []string{"."}
+	}
+	listCmd := exec.Command(goCmdName, append([]string{"list"}, patterns...)...)
+	listCmd.Dir = wd
+	listOut, err := listCmd.Output()
+	if err != nil {
+		// things will fail later per existing GopherJS behaviour
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	res := strings.Split(strings.TrimSpace(string(listOut)), "\n")
+
+	if !useVgo {
+		return res, nil
+	}
+
+	pkgMap = make(map[string]*build.Package)
+
+	args := append([]string{"list", "-json", "-deps", "-test", "-tags", strings.Join(append(c.BuildTags, "js"), " ")}, res...)
+
+	cmd := exec.Command(goCmdName, args...)
+	cmd.Dir = wd
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run %q for Import in %v for context %#v: %v", strings.Join(cmd.Args, " "), cmd.Dir, c, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for {
+		var p build.Package
+		err := dec.Decode(&p)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to json decode for Import: %v", err)
+		}
+		pkgMap[p.ImportPath] = &p
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
* Only partial support; still somewhat relies on being in a correctly formed `GOPATH`

TODO:

* Fix build https://circleci.com/gh/myitcv/gopherjs/51
* Add tests to ensure both modes of GopherJS (`go` and `vgo` continue to work as expected); this will be a sample project building
* Full support for `GOPATH`-less development. e.g. serving `example.com/hello` with no `GOPATH` set or that module not being in the `GOPATH`